### PR TITLE
fix: add null check for `oldState.channel`

### DIFF
--- a/handlers/voiceHandler.js
+++ b/handlers/voiceHandler.js
@@ -221,7 +221,7 @@ function setupVoiceHandler(client) {
                 memberId,
                 username,
                 oldState.channelId,
-                oldState.channel.name,
+                oldState.channel?.name || 'Deleted Channel',
                 minutes
             );
 


### PR DESCRIPTION
Prevented crash when oldState.channel is null by adding a fallback to 'Deleted Channel' in voiceHandler.

fixes #19 