### PR TITLE
fix: standardize env variables across codebase.

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -50,7 +50,7 @@ const rest = new REST().setToken(process.env.DISCORD_BOT_TOKEN);
 
     // The put method is used to fully refresh all commands in the guild with the current set
     const data = await rest.put(
-      Routes.applicationCommands(process.env.CLIENT_ID),
+      Routes.applicationCommands(process.env.DISCORD_CLIENT_ID),
       { body: commands },
     );
 


### PR DESCRIPTION
Replaced all instances of `CLIENT_ID` with `DISCORD_CLIENT_ID` to ensure consistent usage of environment variables throughout the codebase.

fixes #24 